### PR TITLE
Enable Vite build sourcemaps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,11 @@ export default defineConfig({
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-varsler-frontend",
   },
+  vite: {
+    build: {
+      sourcemap: true,
+    },
+  },
   integrations: [react()],
   logger: {
     entrypoint: "@navikt/astro-logger",


### PR DESCRIPTION
Sourcemaps make it easier to debug production errors by mapping minified stack traces back to original source locations.

Adds `vite.build.sourcemap: true` to the Astro config, following the same pattern as navikt/tms-utkast-frontend#168.