### PR TITLE
feat: use @navikt/astro-auth for authentication middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@navikt/astro-logger": "1.0.0",
     "@navikt/ds-react": "8.10.4",
     "@navikt/nav-dekoratoren-moduler": "3.4.0",
+    "@navikt/astro-auth": "1.0.7",
     "@navikt/oasis": "3.8.0",
     "astro": "7.0.3",
     "dayjs": "1.11.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@navikt/aksel-icons':
         specifier: 8.10.5
         version: 8.10.5
+      '@navikt/astro-auth':
+        specifier: 1.0.7
+        version: 1.0.7(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.0.14)(rollup@4.60.2)(tsx@4.22.1)(yaml@2.9.0))
       '@navikt/astro-logger':
         specifier: 1.0.0
         version: 1.0.0(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.0.14)(rollup@4.60.2)(tsx@4.22.1)(yaml@2.9.0))(pino@9.14.0)
@@ -927,6 +930,12 @@ packages:
   '@navikt/aksel-icons@8.10.5':
     resolution: {integrity: sha512-XDmygarYMyGhGxE5x5uVDCxPPW5dty2A0yVvdT+I6VyRjvDDY/jtAw0NU/HV5itAm7prCwO19IKf1DvjuzU31g==, tarball: https://npm.pkg.github.com/download/@navikt/aksel-icons/8.10.5/5904f4043e27a4f7f7005fd9fd2fe1ceed130d3b}
 
+  '@navikt/astro-auth@1.0.7':
+    resolution: {integrity: sha512-pbu65DmwMXFSMcJqyvBvKTST3oopuxt/rgMHnoEj3jLfG/wEBmUJjubzsrmod3pG7NdpdS4PjlHu0Ym8rkJlJA==, tarball: https://npm.pkg.github.com/download/@navikt/astro-auth/1.0.7/9d48f02604cdc647e81801442e4b79ad66c93f43}
+    engines: {node: ^20.19.0 || >= 22.12.0 || 24.x}
+    peerDependencies:
+      astro: ^7.0.0
+
   '@navikt/astro-logger@1.0.0':
     resolution: {integrity: sha512-4PlhIDb5g9I9yGPNri6aoAN9EZrtADerzOky3HMET4+T50Nl6aJvJF+ov2XumMPStTFrgxOvb6zGAi0nj9hVJg==, tarball: https://npm.pkg.github.com/download/@navikt/astro-logger/1.0.0/8465e16527b5b42c04338723e9a676da6412a8f7}
     engines: {node: ^20.19.0 || >= 22.12.0 || 24.x}
@@ -961,6 +970,14 @@ packages:
 
   '@navikt/oasis@3.8.0':
     resolution: {integrity: sha512-5CDsv3wop9eIw2YNBCJRr0w6PwwkoTiHzZQXn1+5YZnsksCkHJAFsfKSbRle6zgsD+XRBnc/TPOP0nvNly7NWg==, tarball: https://npm.pkg.github.com/download/@navikt/oasis/3.8.0/fc6862d934adfbefa382220614af18160688cd1e}
+
+  '@navikt/oasis@4.1.4':
+    resolution: {integrity: sha512-v+LW8V5CTiHkfIXhceQ8RXRtrBktCK8wSFYmiR6hmzl9CJRYRLUpFC7YbLiC7jwHIuLHKUyl+Zawf8zQm6fDeQ==, tarball: https://npm.pkg.github.com/download/@navikt/oasis/4.1.4/0d9c93820b9b6d93b1bd9da134feb95461ad8a47}
+    engines: {node: ^20.19.0 || >= 22.12.0 || 24.x || 25.x}
+
+  '@navikt/texas@4.1.4':
+    resolution: {integrity: sha512-WS+agfWCqHyCtIpn/iQHNBRwn1gzCQDe0NY9Tz5ErrBsWHNxtqIV7W2eAmRUa3DLrZGHczoQhup+PYT6UX/SpQ==, tarball: https://npm.pkg.github.com/download/@navikt/texas/4.1.4/1725aca0fa0b803e0048212c3e202d24c10f3c3b}
+    engines: {node: ^20.19.0 || >= 22.12.0 || 24.x || 25.x}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -1956,6 +1973,9 @@ packages:
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -3725,6 +3745,11 @@ snapshots:
 
   '@navikt/aksel-icons@8.10.5': {}
 
+  '@navikt/astro-auth@1.0.7(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.0.14)(rollup@4.60.2)(tsx@4.22.1)(yaml@2.9.0))':
+    dependencies:
+      '@navikt/oasis': 4.1.4
+      astro: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.0.14)(rollup@4.60.2)(tsx@4.22.1)(yaml@2.9.0)
+
   '@navikt/astro-logger@1.0.0(astro@7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.0.14)(rollup@4.60.2)(tsx@4.22.1)(yaml@2.9.0))(pino@9.14.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -3760,6 +3785,15 @@ snapshots:
       jose: 5.10.0
       openid-client: 5.7.1
       prom-client: 15.1.3
+
+  '@navikt/oasis@4.1.4':
+    dependencies:
+      '@navikt/texas': 4.1.4
+      '@opentelemetry/api': 1.9.1
+      jose: 6.2.3
+      prom-client: 15.1.3
+
+  '@navikt/texas@4.1.4': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -4764,6 +4798,8 @@ snapshots:
   jose@4.15.9: {}
 
   jose@5.10.0: {}
+
+  jose@6.2.3: {}
 
   js-cookie@3.0.5: {}
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,12 +1,6 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 
-declare namespace App {
-  interface Locals {
-    token: string;
-  }
-}
-
 interface ImportMetaEnv {
   PUBLIC_APP_ENVIRONMENT: "local" | "dev" | "prod";
 }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,30 +1,3 @@
-import { getToken, validateToken } from "@navikt/oasis";
-import { loginUrl } from "@utils/urls.ts";
-import { defineMiddleware } from "astro/middleware";
+import { authenticate } from "@navikt/astro-auth";
 
-const isLocal = import.meta.env.DEV;
-
-export const onRequest = defineMiddleware(async (context, next) => {
-  const token = getToken(context.request.headers);
-  if (isLocal) {
-    return next();
-  }
-
-  if (context.request.url.includes("/internal")) {
-    return next();
-  }
-
-  if (!token) {
-    context.logger.info("Token not found");
-    return context.redirect(loginUrl);
-  }
-
-  const validation = await validateToken(token);
-  if (!validation.ok) {
-    context.logger.error("Validation failed!");
-    return context.redirect(loginUrl);
-  }
-
-  context.locals.token = token;
-  return next();
-});
+export const onRequest = authenticate();

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -28,5 +28,4 @@ export const inaktiverBeskjedApiUrl = `${NAV_NO_URL[environment]}/tms-varsel-api
 export const loginStepUpUrl = `${appBaseUrl}/oauth2/login?level=Level4&redirect=${appBaseUrl}`;
 
 export const apiInternIngress = `${API_INTERNAL_INGRESS[environment]}/alle`;
-export const loginUrl = `/minside/varsler/oauth2/login?redirect=${appBaseUrl}`;
 export const errorReportingUrl = ERROR_REPORTING_URL[environment];


### PR DESCRIPTION
Replaces the custom authentication middleware with `@navikt/astro-auth`'s `authenticate()` function.

## Why

The hand-rolled middleware duplicates logic that `@navikt/astro-auth` already encapsulates (token extraction, validation, login redirect, skipping internal routes, and setting `locals.token`). Using the shared library reduces maintenance burden and keeps auth behavior consistent across Nav's Astro apps.

## What changed

- `src/middleware/index.ts` -- replaced ~30 lines of manual auth logic with a single `authenticate()` call
- Added `@navikt/astro-auth` as a dependency
- `@navikt/oasis` remains since it is still used for OBO token exchange elsewhere