### PR TITLE
Legg til Digestabot-workflow

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,24 @@
+name: "Check for newer image versions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every monday at 08:00.
+    - cron: "0 8 * * 1"
+
+jobs:
+  digest-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: navikt/digestabot@3302a753e533ceb9ec216de7f78345436cd636e3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          team: min-side


### PR DESCRIPTION
Digestabot skal holde image-versjoner oppdatert automatisk i stedet for at de må følges opp manuelt.

Workflowen kjører hver mandag kl. 08:00 UTC og kan også startes manuelt. Den bruker SHA-pinnede actions, avgrensede skrivetilganger og `min-side` som team.