### PR TITLE
Bytt til Chainguard Node 24-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim@sha256:8b0b8c0d78166534d392bfb670f96fa6d443cec16169481788aa1ed27dfc4a7d
 
 WORKDIR usr/src/app
 COPY ./dist ./dist


### PR DESCRIPTION
Erstatter Google Distroless med Navs pinnede Chainguard Node 24-image. Dette samsvarer med oppsettet i `tms-utkast-frontend` og bruker Navs pull-through registry.